### PR TITLE
[Issue #1]: fixes for other envs & message friendliness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-builtin-variables
 
 YMD = $(shell date +%Y-%m-%d)
-LOGNAME = $(shell logname || echo "$$LOGNAME" || echo "$$USER")
+LOGNAME = $(shell echo "$${LOGNAME:-$${USER:-UNKNOWN}}")
 DATA_DIR = Data
 DATA_FILE = $(DATA_DIR)/$(LOGNAME).$(YMD).tsv
 CHART_FILE = $(DATA_DIR)/$(LOGNAME).$(YMD).png
@@ -24,7 +24,7 @@ $(DATA_FILE): my-speedtest.many
 	#
 	# Collect internet speed data into $(DATA_FILE)
 	#
-	mkdir -p $(DATA_DIR)
+	mkdir -vp $(DATA_DIR)
 	./my-speedtest.many > $(DATA_FILE).tmp && \
 		mv $(DATA_FILE).tmp $(DATA_FILE)
 

--- a/check-prereqs
+++ b/check-prereqs
@@ -47,7 +47,7 @@ function check-only() {
 
     for prog in $NEEDED_BASE_PROGS; do
         if command -v "$prog" >/dev/null 2>&1; then
-            echo "Cool: base program $prog is installed"
+            echo "base program $prog is installed: ok"
         else
             ((++error_count))
         fi
@@ -57,7 +57,7 @@ function check-only() {
         if ! r-has-module "$module"; then
             ((++error_count))
         else
-            echo "Cool: R package $pkg is installed"
+            echo "R package $pkg is installed: ok"
         fi
     done
     if [[ $error_count > 0 ]]; then
@@ -72,4 +72,3 @@ function check-only() {
 # -- main
 #
 check-only
-

--- a/my-speedtest.many
+++ b/my-speedtest.many
@@ -60,9 +60,10 @@ sub init {
 sub closest_n_servers($) {
     my $n = shift;
     my @server_ids = ();
+    my $list_command = 'speedtest --list';
 
     my $good_count = 0;
-    open(my $inp, "speedtest --list |");
+    open(my $inp, "$list_command |");
     while (my $line = <$inp>) {
         next if ($line =~ /$UnreliableServers/o);
 
@@ -81,6 +82,10 @@ sub closest_n_servers($) {
         last if ($good_count >= $n);
     }
     close $inp;
+    unless (@server_ids) {
+        die "closest_n_servers($n): unable to get any servers\n" .
+            "Something's wrong with '$list_command'?\n";
+    }
     @server_ids;
 }
 
@@ -160,4 +165,4 @@ printf STDERR
 
 # exit status == 0 means success in the calling shell,
 # so need to invert the condition
-exit ($success_pct < $MinSuccessPct);
+exit (! ($success_count > 0));


### PR DESCRIPTION
Makefile:
    - Don't rely on logname utility
    - Add $LOGNAME fallbacks: $USER, 'UNKNOWN'
    - Add -v to mkdir

check-prereqs:
    - Don't use 'Cool' (Americanism)

my-speedtest.many:
    - Don't exit error iff there was at least one success
    - Avoid div-by-0; issue early error on 'speedtest --list' failure